### PR TITLE
Bugfix: Unescaped RegEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [0.4.4](https://github.com/aacn/eslint-plugin-tailwind-classname-order/releases/tag/v0.4.4) - 2025-04-22
+
+### Fixed
+- Fixed a bug that caused the linting to fail as a regex run into an unescaped sequence, caused by variables beeing inluced inside the className string.
+
 ## [0.4.3](https://github.com/aacn/eslint-plugin-tailwind-classname-order/releases/tag/v0.4.3) - 2023-06-20
 ### Updated
 - Updated the order config to include newly added/missing prefixes, especially focusing on the upcoming support for `aria` tags.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aacn.eu/eslint-plugin-tailwind-classname-order",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Automatically orders tailwind classes included in the className tags from each element by the provided default order list.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/util/escape-classname.ts
+++ b/src/util/escape-classname.ts
@@ -1,0 +1,9 @@
+/**
+ * Function to escape potential symbols in a className string that could break a regex test, because they're not escaped.
+ * @param string
+ */
+function escapeClassname(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export {escapeClassname}

--- a/src/util/order-classes.ts
+++ b/src/util/order-classes.ts
@@ -3,6 +3,7 @@ import { sanitizeNode } from "@/util/sanitize-node";
 import orderList from "@/rules/orderConfig.json";
 import { stripString } from "@/util/strip-string";
 import { OrderProps } from "@/types/OrderProps";
+import { escapeClassname } from "@/util/escape-classname";
 
 class OrderClasses {
   /**
@@ -181,8 +182,10 @@ class OrderClasses {
    * @return priority of the given classname or -1 if not found
    */
   private findTailwindClass(className: string) {
+    const escapedClassName = escapeClassname(className);
+
     //add regex to prevent search from grabing classnames that include the provided term, but aren't the class that was searched for
-    const regex = new RegExp(`((?!-)( |^))${className}(($| )(?!-))`, "gm");
+    const regex = new RegExp(`((?!-)( |^))${escapedClassName}(($| )(?!-))`, "gm");
     return orderList.priority.findIndex(elem => regex.test(elem));
   }
 


### PR DESCRIPTION
## Changelog
### Fixed

- Fixed a bug that caused the linting to fail as a regex run into an unescaped sequence, caused by variables beeing inluced inside the className string.
